### PR TITLE
Update templates to use ProjectName, matching Hydrator struct

### DIFF
--- a/ops/main.tf
+++ b/ops/main.tf
@@ -151,7 +151,7 @@ module "fargate_alb" {
   tags = {
     environment          = "dev"
     terraform            = "True"
-    crosstree-id         = var.project_id
+    crosstree-id         = var.project_name
     crosstree-repository = var.repo_name
   }
 }

--- a/ops/variables.tf
+++ b/ops/variables.tf
@@ -21,10 +21,10 @@ variable "repo_name" {
   default     = "{{ .RepoName }}"
 }
 
-variable "project_id" {
-  description = "the crosstree project id"
+variable "project_name" {
+  description = "the crosstree project name"
   type        = string
-  default     = "{{ .ProjectID }}"
+  default     = "{{ .ProjectName }}"
 }
 
 variable "region" {


### PR DESCRIPTION
Running a `crosstree generate` gives the following error:

```
Unable to hydrate skeleton: template: _:27:20: executing "_" at <.ProjectID>: can't evaluate field ProjectID in type *crosstree.Hydrator
```

This PR changes the terraform variable name to `project_name` and uses the golang reference to `ProjectName` in the template to match the nomenclature and variable name used in the code that fills the template.