### PR TITLE
Remove OIDC from terraform control

### DIFF
--- a/ops/main.tf
+++ b/ops/main.tf
@@ -48,7 +48,7 @@ data "aws_iam_policy_document" "github_actions_assume_role" {
     actions = ["sts:AssumeRoleWithWebIdentity"]
     principals {
       type        = "Federated"
-      identifiers = [{{ .OIDCProviderARN }}]
+      identifiers = [{{ .OIDCProviderArn }}]
     }
     condition {
       test     = "StringLike"


### PR DESCRIPTION
AWS only allows one OIDC provider per URL per account, so crosstree was tripping over itself trying to overwrite a value that couldn't be overwritten.

To fix that, make the OIDC provider managed by crosstree instead of each crostree app's terraform.

depends on https://github.com/adhocteam/crosstree/commit/cdd8bb2394c520d8bf3ff9cf82d4862cd16656c7